### PR TITLE
prism_periph: fix syntax error in fpga variant

### DIFF
--- a/src/prism_periph.v
+++ b/src/prism_periph.v
@@ -580,7 +580,7 @@ module tqvp_prism (
                 ctrl_reg <= ctrl_bits_in;
 
             if (count1_reg_en & prism_wr)
-                count_preloads{23:0] <= data_in;
+                count_preloads[23:0] <= data_in;
             if ((count2_reg_en | count1_toggle_en) & prism_wr)
                 count_preloads[31:24] <= data_in;
         end


### PR DESCRIPTION
I encountered this error when trying to build the FPGA version of https://github.com/TinyTapeout/ttsky25a-tinyQV